### PR TITLE
ci: add Dependabot config and auto-merge workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,29 @@
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+# Default token to no permissions; the auto-merge job below requests just
+# what it needs.
+permissions: {}
+
+jobs:
+  automerge:
+    name: Auto-merge safe Dependabot PRs
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

Dependabot を導入し、patch/minor 更新の PR を CI 通過後に自動マージする構成を追加します。

- `dependabot.yml`: npm と github-actions を weekly で更新
- auto-merge ワークフロー: `dependabot[bot]` の patch/minor PR のみ `gh pr merge --auto --squash`（major は除外）

## 備考
auto-merge を機能させるためリポジトリ設定の **Allow auto-merge** を別途有効化済み。